### PR TITLE
plugin to override suggested facets

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,13 +1,3 @@
 {
-  "databases": {
-    "articles": {
-      "tables": {
-        "articles": {
-          "facets": [
-             {"array": "MeSH"},
-          ]
-        }
-      }
-    }
-  }
+  "extra_js_urls": ["/static/js/vax.js"]
 }

--- a/plugins/facets.py
+++ b/plugins/facets.py
@@ -1,0 +1,41 @@
+import urllib.parse
+from datasette import hookimpl, utils
+
+
+def absolute_url(request, path):
+    return urllib.parse.urljoin(request.url, path)
+
+
+def qs_key(value):
+    return f'_facet_{value.get("type", "")}'.rstrip('_')
+
+
+@hookimpl
+def extra_template_vars(request):
+    columns = [
+        {'name': 'Section'},
+        {'name': 'PubType'},
+        {'name': 'PubDate', 'type': 'date'},
+        {'name': 'Main_Topic', 'type': 'array'},
+        {'name': 'Demographics', 'type': 'array'},
+        {'name': 'MeSH', 'type': 'array'},
+        {'name': 'Author(s)', 'type': 'array'},
+        {'name': 'Affiliation', 'type': 'array'},
+    ]
+
+    suggested_facets = [
+        {
+            'name': column['name'],
+            'type': column.get('type', ''),
+            'toggle_url': absolute_url(
+                request,
+                utils.path_with_added_args(
+                    request,
+                    {qs_key(column): column['name']}
+                )
+            )
+        }
+        for column in columns
+    ]
+
+    return {"suggested_facets": suggested_facets}

--- a/static/js/vax.js
+++ b/static/js/vax.js
@@ -1,0 +1,4 @@
+document.addEventListener("DOMContentLoaded", function() {
+    const suggested_facets = document.querySelector('.suggested-facets');
+    suggested_facets.innerHTML = suggested_facets.innerHTML.replace(/ (\(array\)|\(date\))/g, '')
+});


### PR DESCRIPTION
Fix for #5.

Remove/add to the `columns`  variable to enable/disable suggested facet fields. Run with 

`
datasette articles.db --plugins-dir=plugins/
`